### PR TITLE
Mypyc Build

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 10
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -47,8 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 10
       - uses: actions/setup-python@v4
         name: Install Python
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -68,14 +68,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Install Dependencies

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,10 +1,8 @@
 name: pypi
 
-# on:
-#   release:
-#     types: [published]
-
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   build_wheels:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,7 +1,7 @@
 name: pypi
 
 on:
-  workflow_dispatch:
+  push:
   release:
     types: [published]
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # cibuildwheel builds linux wheels inside a manylinux container
-        # it also takes care of procuring the correct python version for us
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [39, 310, 311]
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -79,4 +79,5 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           poetry config pypi-token.pypi $PYPI_TOKEN
+          poetry version $(git describe --tags --abbrev=0)
           poetry publish

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,18 +1,84 @@
 name: pypi
 
-on:
-  release:
-    types: [published]
+# on:
+#   release:
+#     types: [published]
+
+on: push
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  build_wheels:
+    name: py${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # cibuildwheel builds linux wheels inside a manylinux container
+        # it also takes care of procuring the correct python version for us
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [39, 310, 311]
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
+      - name: set version
+        run: |
+          pip install poetry
+          poetry version $(git describe --tags --abbrev=0)
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - uses: pypa/cibuildwheel@v2.11.1
+        env:
+          CIBW_BUILD: "cp${{ matrix.python-version}}-*"
+          CIBW_ARCHS_MACOS: x86_64 arm64
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: sdist and python wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: "3.8"
+      - name: Build Sdist
+        run: |
+          pip install poetry
+          poetry version $(git describe --tags --abbrev=0)
+          poetry publish
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: |
+            dist/*.tar.gz
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build_wheels, build_sdist]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
       - name: Install Dependencies
         run: pip install poetry
       - name: Build & Upload
@@ -20,6 +86,4 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           poetry config pypi-token.pypi $PYPI_TOKEN
-          poetry version $(git describe --tags --abbrev=0)
-          poetry build
           poetry publish

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,6 +1,7 @@
 name: pypi
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -33,8 +33,6 @@ jobs:
       - uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
-          # CIBW_ARCHS_MACOS: x86_64 arm64
-          # CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
       - uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,6 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - run: git fetch --prune --unshallow --tags
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -43,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - run: git fetch --prune --unshallow --tags
       - uses: actions/setup-python@v4
         name: Install Python
         with:
@@ -63,6 +65,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     steps:
       - uses: actions/checkout@v3
+      - run: git fetch --prune --unshallow --tags
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
           CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
       - uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           pip install poetry
           poetry version $(git describe --tags --abbrev=0)
-          poetry publish
+          poetry build
       - uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -45,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
       - uses: actions/setup-python@v4
         name: Install Python
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -79,5 +79,6 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           poetry config pypi-token.pypi $PYPI_TOKEN
+          poetry config repositories.test-pypi https://test.pypi.org/legacy/
           poetry version $(git describe --tags --abbrev=0)
           poetry publish

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -81,4 +81,4 @@ jobs:
           poetry config pypi-token.test-pypi $PYPI_TOKEN
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
           poetry version $(git describe --tags --abbrev=0)
-          poetry publish
+          poetry publish -r test-pypi

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,8 +2,8 @@ name: pypi
 
 on:
   push:
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   build_wheels:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,18 +28,15 @@ jobs:
         run: |
           pip install poetry
           poetry version $(git describe --tags --abbrev=0)
-
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all
-
       - uses: pypa/cibuildwheel@v2.11.1
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
           CIBW_ARCHS_MACOS: x86_64 arm64
-
       - uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
-          poetry config pypi-token.pypi $PYPI_TOKEN
+          poetry config pypi-token.test-pypi $PYPI_TOKEN
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
           poetry version $(git describe --tags --abbrev=0)
           poetry publish

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,9 +1,9 @@
 name: pypi
 
 on:
-  push:
-  # release:
-  #   types: [published]
+  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build_wheels:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -35,8 +35,8 @@ jobs:
       - uses: pypa/cibuildwheel@v2.11.1
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
-          CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+          # CIBW_ARCHS_MACOS: x86_64 arm64
+          # CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
       - uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -78,7 +78,6 @@ jobs:
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
-          poetry config pypi-token.test-pypi $PYPI_TOKEN
-          poetry config repositories.test-pypi https://test.pypi.org/legacy/
+          poetry config pypi-token.pypi $PYPI_TOKEN
           poetry version $(git describe --tags --abbrev=0)
-          poetry publish -r test-pypi
+          poetry publish

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v2.11.1
+      - uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
           # CIBW_ARCHS_MACOS: x86_64 arm64

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+setup.py
 .Python
 build/
 develop-eggs/

--- a/build.py
+++ b/build.py
@@ -1,0 +1,12 @@
+from mypyc.build import mypycify
+
+mypyc_paths = [
+    "pycooldown/__init__.py",
+    "pycooldown/fixed_mapping.py",
+    "pycooldown/flexible_mapping.py",
+    "pycooldown/sliding_window.py",
+]
+
+
+def build(setup_kwargs):
+    setup_kwargs["ext"] = mypycify(mypyc_paths)

--- a/build.py
+++ b/build.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from mypyc.build import mypycify  # type: ignore
@@ -13,4 +14,7 @@ mypyc_paths = [
 
 
 def build(setup_kwargs: dict[str, Any]) -> None:
+    # Don't build wheels in CI.
+    if os.environ.get("CI", False):
+        return
     setup_kwargs["ext_modules"] = mypycify(mypyc_paths)

--- a/build.py
+++ b/build.py
@@ -1,4 +1,8 @@
-from mypyc.build import mypycify
+from __future__ import annotations
+
+from typing import Any
+
+from mypyc.build import mypycify  # type: ignore
 
 mypyc_paths = [
     "pycooldown/__init__.py",
@@ -8,5 +12,5 @@ mypyc_paths = [
 ]
 
 
-def build(setup_kwargs):
+def build(setup_kwargs: dict[str, Any]) -> None:
     setup_kwargs["ext_modules"] = mypycify(mypyc_paths)

--- a/build.py
+++ b/build.py
@@ -9,4 +9,4 @@ mypyc_paths = [
 
 
 def build(setup_kwargs):
-    setup_kwargs["ext"] = mypycify(mypyc_paths)
+    setup_kwargs["ext_modules"] = mypycify(mypyc_paths)

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ def pytest_and_mypy(session: nox.Session) -> None:
     session.install("poetry")
     session.run("poetry", "install")
 
-    session.run("mypy", ".")
+    session.run("mypy", "pycooldown")
     session.run(
         "poetry",
         "run",

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,6 +3,9 @@ import nox
 
 @nox.session
 def pytest_and_mypy(session: nox.Session) -> None:
+    # Tell `build.py` that wheels shouldn't be built.
+    session.env["CI"] = "True"
+
     session.install("poetry")
     session.run("poetry", "install")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/TrigonDev/pycooldown"
 repository = "https://github.com/TrigonDev/pycooldown"
-keywords = ["cython", "ratelimit", "cooldown"]
+keywords = ["mypyc", "ratelimit", "cooldown"]
 build = "build.py"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ pytest-mock = "^3.7.0"
 mock = "^4.0.3"
 
 [tool.cibuildwheel.macos]
-archs = ["universal2"]
+archs = ["auto", "universal2"]
+test-skip = ["*universal2:arm64"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64", "ppc64le", "s390x"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,9 @@ pytest-mock = "^3.7.0"
 mock = "^4.0.3"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "setuptools", "mypy"]
+requires = [
+    "poetry-core>=1.0.0",
+    "setuptools",
+    "mypy",
+]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,10 @@ pytest-mock = "^3.7.0"
 mock = "^4.0.3"
 
 [tool.cibuildwheel.macos]
-archs = ["auto", "arm64"]
+archs = ["auto"]
 
 [tool.cibuildwheel.linux]
-# archs = ["auto", "aarch64", "ppc64le", "s390x"]
-archs = ["auto"]
+archs = ["auto", "aarch64", "ppc64le", "s390x"]
 
 [build-system]
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pytest-mock = "^3.7.0"
 mock = "^4.0.3"
 
 [tool.cibuildwheel.macos]
-archs = ["arm64"]
+archs = ["universal2"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64", "ppc64le", "s390x"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 homepage = "https://github.com/TrigonDev/pycooldown"
 repository = "https://github.com/TrigonDev/pycooldown"
 keywords = ["cython", "ratelimit", "cooldown"]
+build = "build.py"
 
 [tool.poetry.dependencies]
 python = "^3.8"
@@ -28,5 +29,5 @@ pytest-mock = "^3.7.0"
 mock = "^4.0.3"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0", "setuptools", "mypy"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pytest-mock = "^3.7.0"
 mock = "^4.0.3"
 
 [tool.cibuildwheel.macos]
-archs = ["auto"]
+archs = ["arm64"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64", "ppc64le", "s390x"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ pytest-cov = "^4.0.0"
 pytest-mock = "^3.7.0"
 mock = "^4.0.3"
 
+[tool.cibuildwheel.macos]
+archs = ["auto", "arm64"]
+
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64", "ppc64le", "s390x"]
+
 [build-system]
 requires = [
     "poetry-core>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ mock = "^4.0.3"
 archs = ["auto", "arm64"]
 
 [tool.cibuildwheel.linux]
-archs = ["auto", "aarch64", "ppc64le", "s390x"]
+# archs = ["auto", "aarch64", "ppc64le", "s390x"]
+archs = ["auto"]
 
 [build-system]
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ pytest-mock = "^3.7.0"
 mock = "^4.0.3"
 
 [tool.cibuildwheel.macos]
-archs = ["auto", "universal2"]
-test-skip = ["*universal2:arm64"]
+archs = ["universal2"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64", "ppc64le", "s390x"]


### PR DESCRIPTION
The wheels build

Issues:
- macos arm64 wheels aren't build because of a bug with cibuildwheel. `universal2` wheels are built that work with macos arm64 but aren't fetched by arm64 errors due to a naming error.
